### PR TITLE
add GTM tag, remove incorrect GA4 tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,35 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MK065DF5XP"></script>
-    <script>
-    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N6ZBCZV');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <%= process.env.VUE_APP_TIER !== '' ? '<meta name="robots" content="noindex,nofollow">' : '' %><!-- an empty string in this case means the 'prod' version of the application   -->
-      <!-- Primary Meta Tags -->
-      <title>
-        <%= VUE_APP_TIER %>
-          <%= VUE_APP_TITLE %>
-      </title>
-      <meta name="title" content="70 years of hydrological drought">
-      <meta name="description" content="">
-      <!-- Open Graph / Facebook -->
-      <meta property="og:type" content="website">
-      <meta property="og:url" content="https://labs.waterdata.usgs.gov/visualizations/gw-conditions/index.html#/">
-      <meta property="og:title" content="70 years of hydrological drought">
-      <meta property="og:description" content="">
-      <meta property="og:image" content="https://labs.waterdata.usgs.gov/visualizations/thumbnails/gw-conditions-og-peaks.png">
-      <!-- Twitter -->
-      <meta property="twitter:card" content="summary_large_image">
-      <meta property="twitter:url" content="https://labs.waterdata.usgs.gov/visualizations/gw-conditions/index.html#/">
-      <meta property="twitter:title" content="70 years of hydrological drought">
-      <meta property="twitter:description" content="">
-      <meta property="twitter:image" content="https://labs.waterdata.usgs.gov/visualizations/thumbnails/gw-conditions-og-peaks.png">
+    <!-- Primary Meta Tags -->
+    <title>
+      <%= VUE_APP_TIER %>
+        <%= VUE_APP_TITLE %>
+    </title>
+    <meta name="title" content="70 years of hydrological drought">
+    <meta name="description" content="">
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://labs.waterdata.usgs.gov/visualizations/gw-conditions/index.html#/">
+    <meta property="og:title" content="70 years of hydrological drought">
+    <meta property="og:description" content="">
+    <meta property="og:image" content="https://labs.waterdata.usgs.gov/visualizations/thumbnails/gw-conditions-og-peaks.png">
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://labs.waterdata.usgs.gov/visualizations/gw-conditions/index.html#/">
+    <meta property="twitter:title" content="70 years of hydrological drought">
+    <meta property="twitter:description" content="">
+    <meta property="twitter:image" content="https://labs.waterdata.usgs.gov/visualizations/thumbnails/gw-conditions-og-peaks.png">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-<script type='application/ld+json'>
+    <script type='application/ld+json'>
       { "@context": "http://www.schema.org",
         "@type": "WebSite", "name": "70 years of hydrological drought",
         "url": "https://labs.waterdata.usgs.gov/visualizations/drought-timeline/index.html#/",
@@ -49,6 +52,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6ZBCZV"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>
       <strong>We're sorry but this application doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>


### PR DESCRIPTION
This PR replaces the gw-conditions GA4 tag that was in the site with the new GTM tag.  Changes to files other than `index.html` are from running lint.

The GTM container has been configured to point to the existing GA4 account.

Tags on existing page: 

![image](https://github.com/DOI-USGS/drought-timeline/assets/54007288/9c341318-9fe6-4562-835c-aae44ce93be5)

Tags on updated page (previewed from local host):

![image](https://github.com/DOI-USGS/drought-timeline/assets/54007288/edfee8b0-1d26-4bca-99d1-2f11026e483a)



Before making a pull request
----------------------------
First . . .
- [X] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [X] Chrome
- [ ] Safari
- [X] Edge
- [X] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)